### PR TITLE
The ability to choose the completion method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The sample project, RMErrorRecoveryAttempterSampleProject, is an iOS app where l
 The alert is presented using the `UIResponder+RMErrorRecovery` category. If the `recovered` parameter of the completion handler is `YES` then the user chose a recovery path and so the message to delete the item is resent.
 
 	- (void)rm_presentError:(NSError *)error completionHandler:(void (^)(BOOL recovered))completionHandler;
+	
+You can also specify which completion method should the UIAlertView use to call the completion handler:
+
+    - (void)rm_presentError:(NSError *)error completionHandler:(void (^)(BOOL recovered))completionHandler completionMethod:(RMErrorRecoveryPresentedErrorCompletionMethod)competionMethod;
 
 On OS X you can use either the following two AppKit methods to present the error.
 

--- a/Source/UIResponder+RMErrorRecovery.h
+++ b/Source/UIResponder+RMErrorRecovery.h
@@ -22,6 +22,15 @@
 //
 
 #import <UIKit/UIKit.h>
+/*!
+ \brief
+ Presented error completion method (which UIAlerViewDelegate's method has to be used for completionHandler)
+ */
+typedef enum : NSInteger {
+    RMErrorRecoveryPresentedErrorCompletionMethodClickedButton = 0,
+    RMErrorRecoveryPresentedErrorCompletionMethodWillDismiss = 1,
+    RMErrorRecoveryPresentedErrorCompletionMethodDidDismiss = 2,
+} RMErrorRecoveryPresentedErrorCompletionMethod;
 
 /*!
 	\brief
@@ -33,9 +42,15 @@
 
 /*!
 	\brief
-	Present an alert from an error. An error that includes an `NSRecoveryAttempterErrorKey` object will include buttons with the `NSLocalizedRecoveryOptionsErrorKey` strings as titles.
+	Present an alert from an error with `RMErrorRecoveryPresentedErrorCompletionMethodClickedButton` completion method. An error that includes an `NSRecoveryAttempterErrorKey` object will include buttons with the `NSLocalizedRecoveryOptionsErrorKey` strings as titles.
  */
 - (void)rm_presentError:(NSError *)error completionHandler:(void (^)(BOOL recovered))completionHandler;
+
+/*!
+ \brief
+ Present an alert from an error with specified completion method. An error that includes an `NSRecoveryAttempterErrorKey` object will include buttons with the `NSLocalizedRecoveryOptionsErrorKey` strings as titles.
+ */
+- (void)rm_presentError:(NSError *)error completionHandler:(void (^)(BOOL recovered))completionHandler completionMethod:(RMErrorRecoveryPresentedErrorCompletionMethod)competionMethod;
 
 #endif
 


### PR DESCRIPTION
Sometimes developers have to use other `UIAlertViewDelegate` methods, such as `-alertView:didDismissWithButtonIndex:` for better user experience.

The ability to choose the completion method in `_RMAlertViewDelegate` would be a great solution.

I added an enum (`RMErrorRecoveryPresentedErrorCompletionMethod`), which has three values:
- <code>RMErrorRecoveryPresentedErrorCompletionMethod<strong>ClickedButton</strong></code>
- <code>RMErrorRecoveryPresentedErrorCompletionMethod<strong>WillDismiss</strong></code>
- <code>RMErrorRecoveryPresentedErrorCompletionMethod<strong>DidDismiss</strong></code>

I also added a new method in `@interface UIResponder (RMErrorRecovery)`:

```
- (void)rm_presentError:(NSError *)error completionHandler:(void (^)(BOOL recovered))completionHandler completionMethod:(RMErrorRecoveryPresentedErrorCompletionMethod)competionMethod;
```

The default value of `completionMethod` is still `RMErrorReco...ClickedButton`, so it is compatible with the old version.

I updated the `README.md` as well, so it contains the information about completion method.

I hope you'll find my pull request useful. :)
