### PR TITLE
Return YES from any Cancel recovery option

### DIFF
--- a/Source/RMErrorRecoveryAttempter.h
+++ b/Source/RMErrorRecoveryAttempter.h
@@ -39,7 +39,7 @@
 
 /*!
 	\brief
-	Adds a cancel recovery option that returns `NO` from the recovery block.
+	Adds a cancel recovery option that returns `YES` from the recovery block.
  */
 - (void)addCancelRecoveryOption;
 

--- a/Source/RMErrorRecoveryAttempter.m
+++ b/Source/RMErrorRecoveryAttempter.m
@@ -71,7 +71,7 @@
 - (void)addCancelRecoveryOption
 {
 	[self addRecoveryOptionWithLocalizedTitle:NSLocalizedString(@"Cancel", @"RMErrorRecoveryAttempter cancel recovery option") recoveryBlock:^ BOOL (void) {
-		return NO;
+		return YES;
 	}];
 }
 


### PR DESCRIPTION
Although the error has not really been "recovered" from, we've successfully followed the user's suggestion. This way, a `NO` result is reserved for a _failure to recover_, not simply a skipped attempt.
