### PR TITLE
Fixed OS X build when using cocoapods.

### DIFF
--- a/Source/UIResponder+RMErrorRecovery.h
+++ b/Source/UIResponder+RMErrorRecovery.h
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#if TARGET_OS_IPHONE
+
 #import <UIKit/UIKit.h>
 
 /*!
@@ -40,3 +42,5 @@
 #endif
 
 @end
+
+#endif

--- a/Source/UIResponder+RMErrorRecovery.m
+++ b/Source/UIResponder+RMErrorRecovery.m
@@ -21,6 +21,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+#if TARGET_OS_IPHONE
+
 #if !defined(__has_feature)
 #define __has_feature(x) 0
 #endif
@@ -83,3 +85,5 @@ static NSString *_RMAlertViewDelegateContext = @"_RMAlertViewDelegateContext";
 }
 
 @end
+
+#endif


### PR DESCRIPTION
Embedded UIResponder code into `#if TARGET_OS_IPHONE` so that it builds without issues for OS X targets when using cocoapods.
